### PR TITLE
 feat: widen batch container to any sliceable type + iterator-driven scheduler (streaming, unknown-length sources)

### DIFF
--- a/docs/dag_new_pipeline_architecture.md
+++ b/docs/dag_new_pipeline_architecture.md
@@ -250,3 +250,62 @@ Pipeline 负责"是什么"（图定义），Executor 负责"怎么跑"（调度�
 - `AdaptiveBatchExecutor` — 动态 batch 大小（roadmap 7.2）
 - `ProfileExecutor` — 包装其他 executor，添加 NVTX/timeline 埋点
 - `DryRunExecutor` — 验证图结构，不提交 Ray 任务
+
+---
+
+## 流式数据消费模型（迭代器驱动 + 自驱动 source）
+
+> 为 hydp-dataflow 的「有状态流式 reader」承接而加。分两步演进，均**向后兼容**（list 输入行为逐字节不变）。
+
+### 第一步：迭代器驱动（不预知 batch 总数）
+
+`_Scheduler` 不再要求预知 batch 总数。`execute(graph, columns)` 的每个 `columns[key]` 只需是**任意 iterable**
+（list / 生成器 / 迭代器）。调度循环从每个 `input_key` 的迭代器**同步取一批**（所有 key 都有下一个才 admit 新
+batch；**任一耗尽 = 源枯竭**），按 `max_batches_inflight` 边拉边 admit，终止条件是「源枯竭 **且** in-flight 清空」。
+`_ctx`/`_status` 按 batch 懒建、完成即释放（TB 级/未知长度源不 OOM、不预扫）。list 输入走 `iter(list)`，老行为不变。
+
+### 第二步：自驱动 source（空 `input_keys` + StopIteration 哨兵）
+
+**动机**：hydp-dataflow 的多 source fan-in（`a=Read(A); b=Read(B); Merge(a,b)`）要**多路并行读**。若在 driver 侧
+顺序 `next(iterA); next(iterB)` 喂 input_key，读取发生在 driver 主线程 → **必然串行**（实测双源 = 1.62× 单源）。
+要真并行，reader 必须是**图内各自的 actor 节点**，由调度器同拍 submit 到不同 actor（实测同批 ra/rb 执行区间重叠
+≈ 满 sleep）。
+
+**机制**：`input_keys` 允许为空。此时每个 `deps==()` 的 root 是**有状态 reader**（`__init__` 持 `ray.data`/任意
+迭代器，`run` 里 `return next(self._it)`）。调度器**乐观 admit** batch（不靠 driver 输入），每批驱动所有 root
+各跑一次 `run`。迭代器枯竭时 `run` 抛 `StopIteration`：
+
+```
+reader.run():  return next(self._it)          # 算子零耦合:只是 Python 迭代器协议,不 import 任何引擎符号
+      │  枯竭
+      ▼
+RunnerActor.run:  except StopIteration: return SOURCE_EXHAUSTED   # worker 内 catch(StopIteration 不能穿
+      │                                                            # 出 remote task,否则变 RayTaskError)
+      ▼
+_Scheduler._on_complete:  isinstance(value, _SourceExhausted)     # driver 侧认哨兵(返回值,非异常,精确)
+      │  → _source_exhausted=True(停 admit) + 作废本 batch(不产出/不下推)
+```
+
+**语义**：「**任一 source 枯竭 → 全图停**」，与迭代器驱动的「任一 input_key `StopIteration` 即停」完全对称。
+不等长源停在**最短**的；抢先多读的那批落进 `_void`、不产出、不串位。
+
+**1-ahead admit 门控**（`_self_driven` 为真时）：driver 侧 input_key 在 admit 前**同步** `next()`、当场知枯竭，不会
+过度 admit；自驱动这边枯竭要等 actor 跑完才知，若乐观 admit 满 `max_inflight`，会在哨兵回来前**级联多 spawn 出界
+的 tick**（bug：3 批数据的 reader 曾跑 7 次）。故门控「同一时刻至多 1 批 source 未跑完」。单 actor reader 的 tick
+本就在 actor 上串行，提前 admit 多个 source tick 不加速读；下游 pipeline overlap 只需「reader[N] 完成即 admit
+N+1」，1-ahead 不损 overlap，代价仅 1 个探测 tick（≈driver next() 撞 StopIteration 那一下）。
+
+**在途竞态收尾**（`_retire_if_drained`）：某 source 先回哨兵作废 batch 时，同批兄弟 source 可能仍在途。不能立即
+pop（它们完成时要查得到自己的 ctx/status），按 per-batch 未完成调用计数 `_batch_inflight` 归零才释放。`_dispatch`
+对已作废/已释放的 batch 加守卫跳过。
+
+**零耦合边界**：算子只 `return next(self._it)`（Python 原生 `StopIteration`），**不 import 哨兵/不认识调度器**。
+`StopIteration→哨兵`的转换、哨兵识别全部收在 RunnerActor / `_Scheduler`（引擎内部执行协议，等价「for 循环认
+StopIteration」）。哨兵 `SOURCE_EXHAUSTED` 是 `_SourceExhausted` 单例，跨 Ray 序列化后 `isinstance` 仍成立
+（按模块路径引用，非对象 identity）。
+
+**约束**：空 `input_keys` 的图**必须**至少有一个终会枯竭的 source root，否则 admit 循环不停（无外部输入 + 无
+枯竭信号 = 无限图）。
+
+**验收**：`test/test_selfdriven_source.py`（正确性 + 边界 + 时间账 bench）。覆盖单源/多源真并行（时间戳重叠）/
+不等长（停最短、对齐不串）/空源/一路先枯竭另一路慢在途的竞态/inflight=1 不死锁/向后兼容 list 输入。

--- a/docs/dag_new_pipeline_architecture.md
+++ b/docs/dag_new_pipeline_architecture.md
@@ -195,6 +195,23 @@ Pipeline 负责"是什么"（图定义），Executor 负责"怎么跑"（调度�
 - Greedy drain：block for 1 ref，然后 timeout=0 捞取所有已完成 ref
 - 上游释放：当某 node 的所有 consumer 都完成时，从 ctx 中删除该 node 的数据
 
+#### ★ per-node `max_inflight` 默认 1 的瓶颈(待讨论/待改)
+
+`NodeSpec.max_inflight` 默认 **1**——即一个节点正跑 batch0 时,batch1 **进不了该节点**、在其 `_ready_q` 排队
+(`_dispatch`: `while q and self._node_inflight[name] < cap`)。这与全局 `max_batches_inflight` 是**两级闸门,取更
+严者**:全局放 N 个 batch 存活,但若某慢节点 per-node=1,后续 batch 卡在它门口,**跨 batch 流水线重叠被掐深度**。
+
+**实测暴露**(2026-07,hydp-dataflow mineru 368 PDF 回归):每节点默认 `max_inflight=1` 的图,比每节点显式设 4
+的等价图慢 **~9.5%**(924s vs 844s)——vLLM 重段成为流水线深度瓶颈,即使全局 inflight=4 也拿不到充分重叠。
+
+**问题**:per-node 默认 1 是否合理?
+- **支持 1**:安全保守——不显式声明并发就不堆积、背压天然紧。对内存/显存敏感的重算子友好。
+- **反对**:与全局 `max_batches_inflight` **语义割裂**——用户设了全局 4、以为有 4 深流水线,却因节点默认 1 拿不到,
+  **反直觉、静默变慢**(正是那 9.5% 的来源,且难自查)。更合理的默认或许是 **per-node 缺省 = `max_batches_inflight`**
+  (节点不额外收紧;要更紧才显式调小),让「全局设多少就真有多深流水线」成立。
+- **折中**:至少在文档/API 显著提示「per-node 默认 1 会限制流水线深度,重段请显式放宽」;或上层框架(如
+  hydp-dataflow 翻译层)把缺省对齐全局。**此默认值的取舍待定,记此 TODO。**
+
 ### 上下文存储
 
 所有 node 输出统一存为 tuple：

--- a/rayorch/container_ops.py
+++ b/rayorch/container_ops.py
@@ -1,0 +1,79 @@
+"""容器操作 —— 让 DAG 的 batch 单元支持任意「可切片容器」,不止 list/tuple。
+
+RayOrch 原本只把 list/tuple 当可切分 batch(_is_shardable / _submit / _validate_output 硬编码 isinstance list)。
+本模块把「切 shard + 拼回」收口成两个鸭子类型 helper,让 pandas.DataFrame / pyarrow.Table / numpy.ndarray
+也能当 batch 单元(表 + 多模态 object 统一)。**不硬依赖 pandas/pyarrow/numpy**——按需惰性 import,只在真遇到
+该类型时才 import,保持 RayOrch 依赖轻。
+
+设计(hydp-dataflow 四探针坐实,见 rayorch-engine.md §4.5):
+  is_sliceable(x)      —— 能否当 batch 切分:list/tuple 或「有 __len__ + 支持 [s:e] 行切/或 .slice」的容器
+  uni_slice(x, s, e)   —— 位置切 [s,e):arrow 用 .slice(offset,length),其余用 x[s:e]
+  uni_concat(parts)    —— 按 rank 顺序拼回:type→拼接分派(list/tuple/DataFrame/Table/ndarray)
+向后兼容:list/tuple 走原路径,旧调用零改动。新增一种容器 = uni_concat 加一支。
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Sequence
+
+
+def _is_arrow_table(x: Any) -> bool:
+    # 鸭子:pyarrow.Table 有 .slice + .num_rows + .schema,且不硬 import pyarrow
+    return (hasattr(x, "slice") and hasattr(x, "num_rows")
+            and hasattr(x, "schema") and hasattr(x, "column_names"))
+
+
+def _is_pandas_df(x: Any) -> bool:
+    # 鸭子:DataFrame 有 .iloc + .columns + .reset_index,避免硬 import pandas
+    return hasattr(x, "iloc") and hasattr(x, "columns") and hasattr(x, "reset_index")
+
+
+def _is_numpy(x: Any) -> bool:
+    return type(x).__module__ == "numpy" and type(x).__name__ == "ndarray"
+
+
+def is_sliceable(x: Any) -> bool:
+    """能否当作 batch 切分单元。str/bytes 不算(它们有 __getitem__ 但不是 batch)。"""
+    if isinstance(x, (str, bytes)):
+        return False
+    if isinstance(x, (list, tuple)):
+        return True
+    if _is_arrow_table(x) or _is_pandas_df(x) or _is_numpy(x):
+        return True
+    return False
+
+
+def uni_slice(x: Any, start: int, end: int) -> Any:
+    """按位置切 [start, end)。arrow 用 .slice(offset,length);list/tuple/numpy/DataFrame 用 x[s:e] 行切。"""
+    if _is_arrow_table(x):
+        return x.slice(start, end - start)
+    return x[start:end]
+
+
+def uni_concat(parts: List[Any]) -> Any:
+    """按 rank 顺序拼回。空 → None。按首元素类型分派(惰性 import 对应库)。"""
+    parts = [p for p in parts if p is not None]
+    if not parts:
+        return None
+    x0 = parts[0]
+
+    if isinstance(x0, list):
+        out: List[Any] = []
+        for p in parts:
+            out.extend(p)
+        return out
+    if isinstance(x0, tuple):
+        out_t: tuple = ()
+        for p in parts:
+            out_t = out_t + tuple(p)
+        return out_t
+    if _is_pandas_df(x0):
+        import pandas as pd
+        return pd.concat(parts, ignore_index=True)
+    if _is_arrow_table(x0):
+        import pyarrow as pa
+        return pa.concat_tables(parts)
+    if _is_numpy(x0):
+        import numpy as np
+        return np.concatenate(parts)
+    raise TypeError(f"uni_concat: 无法拼接类型 {type(x0).__name__}(非 list/tuple/DataFrame/Table/ndarray)")

--- a/rayorch/dag_new_pipeline.py
+++ b/rayorch/dag_new_pipeline.py
@@ -32,6 +32,7 @@ from typing import Any, Deque, Dict, List, Mapping, Optional, Sequence, Tuple
 import ray
 
 from .dispatch_mode import Dispatch
+from .container_ops import is_sliceable as _is_sliceable
 from .ray_module import RayModule
 
 
@@ -223,9 +224,10 @@ class Executor(ABC):
 def _validate_output(spec: NodeSpec, value: Any) -> None:
     """Check that a node's return value matches its declared ``num_outputs``."""
     if spec.num_outputs == 1:
-        if not isinstance(value, list):
+        if not _is_sliceable(value):
             raise TypeError(
-                f"node '{spec.name}' must return list (got {type(value).__name__})"
+                f"node '{spec.name}' must return a sliceable batch "
+                f"(list/tuple/DataFrame/Table/ndarray, got {type(value).__name__})"
             )
         return
     if not isinstance(value, (tuple, list)):
@@ -239,9 +241,9 @@ def _validate_output(spec: NodeSpec, value: Any) -> None:
             f"but returned {len(value)} outputs"
         )
     for i, branch in enumerate(value):
-        if not isinstance(branch, list):
+        if not _is_sliceable(branch):
             raise TypeError(
-                f"node '{spec.name}' output[{i}] must be list "
+                f"node '{spec.name}' output[{i}] must be a sliceable batch "
                 f"(got {type(branch).__name__})"
             )
 
@@ -438,16 +440,16 @@ class _Scheduler:
         kw = {k: ctx[ref.node][ref.index] for k, ref in spec.kw_args.items()}
 
         for i, v in enumerate(args):
-            if not isinstance(v, list):
+            if not _is_sliceable(v):
                 raise TypeError(
-                    f"node '{spec.name}' arg[{i}] must be list "
-                    f"(got {type(v).__name__})"
+                    f"node '{spec.name}' arg[{i}] must be a sliceable batch "
+                    f"(list/tuple/DataFrame/Table/ndarray, got {type(v).__name__})"
                 )
         for k, v in kw.items():
-            if not isinstance(v, list):
+            if not _is_sliceable(v):
                 raise TypeError(
-                    f"node '{spec.name}' kwarg '{k}' must be list "
-                    f"(got {type(v).__name__})"
+                    f"node '{spec.name}' kwarg '{k}' must be a sliceable batch "
+                    f"(list/tuple/DataFrame/Table/ndarray, got {type(v).__name__})"
                 )
 
         future = spec.module.remote(*args, **kw)

--- a/rayorch/dag_new_pipeline.py
+++ b/rayorch/dag_new_pipeline.py
@@ -33,7 +33,7 @@ import ray
 
 from .dispatch_mode import Dispatch
 from .container_ops import is_sliceable as _is_sliceable
-from .ray_module import RayModule
+from .ray_module import RayModule, SOURCE_EXHAUSTED, _SourceExhausted
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -361,13 +361,28 @@ class _Scheduler:
                 f"input keys mismatch: expected {graph.input_keys}, "
                 f"got {tuple(input_columns.keys())}"
             )
-        if not graph.input_keys:
-            raise ValueError("input columns cannot be empty")
+        # input_keys 允许为空:纯「自驱动 source」图(每个 root 是有状态流式 reader,自产 batch、
+        # 迭代器枯竭时其 run 抛 StopIteration → RunnerActor 转成 SOURCE_EXHAUSTED 哨兵)。此时无 driver
+        # 侧输入,batch 由 root source 乐观 admit、靠哨兵终止(见 _on_complete)。约束:空 input_keys 的图
+        # **必须**至少有一个终会枯竭的 source root,否则 admit 循环不会停(无外部输入 + 无枯竭信号 = 无限图)。
         # 每个 input_key 一个迭代器（list/生成器/任意 iterable 统一 iter()）
         self._iters: Dict[str, "Iterator[Any]"] = {
             k: iter(v) for k, v in input_columns.items()
         }
         self._source_exhausted = False
+        self._void: set[int] = set()                 # 已 admit 但因 source 枯竭而作废、不产出的 batch
+
+        # ── 自驱动图(空 input_keys):source root 是有状态 reader,枯竭信号异步(reader run 回哨兵)──
+        # 与 driver 侧 input_keys 不同:那边 admit 前同步 next()、当场知枯竭,不会过度 admit。自驱动这边
+        # 枯竭要等 actor 跑完才知,若乐观 admit 满 max_inflight 会在哨兵回来前级联多 spawn 出界的 tick。
+        # 故门控:**同一时刻至多 1 批「source 未跑完」的 tick**(1-ahead)。单 actor reader 的 tick 本就在
+        # actor 上串行,提前 admit 多个 source tick 不加速读;下游 pipeline overlap 只需「reader[N] 完成即
+        # admit N+1、同时 N 的下游在跑」,1-ahead 不损 overlap。代价仅 1 个探测 tick(≈driver 侧 next() 撞
+        # StopIteration 那一下)。非自驱动图 self._self_driven=False,门控不触发,老行为逐字节不变。
+        # _src_left[bi]=该 batch 尚未完成的 source 节点数;keys 即「source 未跑完」的 batch(门控依据)。
+        self._self_driven = not graph.input_keys
+        self._source_nodes = tuple(n for n in graph.topo_order if not graph.deps[n])
+        self._src_left: Dict[int, int] = {}
 
         # 按 batch 懒建(dict[bi] 而非 list[N])——不预知总数、完成即可释放
         self._ctx: Dict[int, Dict[str, tuple]] = {}
@@ -379,6 +394,7 @@ class _Scheduler:
 
         self._live: set[int] = set()
         self._next_batch = 0
+        self._batch_inflight: Dict[int, int] = {}    # per-batch 未完成调用数(作废 batch 收尾用)
 
         self._ref_owner: Dict[ray.ObjectRef, _InflightCall] = {}
         self._outstanding: set[ray.ObjectRef] = set()
@@ -438,6 +454,10 @@ class _Scheduler:
     def _admit_batches(self) -> None:
         # 迭代器驱动:边拉边 admit,拿不到(源枯竭)就停;不依赖 len(columns)。
         while len(self._live) < self._max_inflight:
+            # 自驱动图 1-ahead 门控:已有一批 source 未跑完(枯竭未知)→ 先别再 admit,避免哨兵回来
+            # 前级联过度 spawn。等那批 source 完成(_on_complete 里清 _src_left)再放行下一批。
+            if self._self_driven and self._src_left:
+                break
             row = self._next_input_row()
             if row is None:
                 break
@@ -446,6 +466,8 @@ class _Scheduler:
             self._live.add(bi)
             self._ctx[bi] = {key: (row[key],) for key in self._graph.input_keys}
             self._status[bi] = {name: _NodeStatus() for name in self._graph.topo_order}
+            if self._self_driven:
+                self._src_left[bi] = len(self._source_nodes)
             for name in self._graph.topo_order:
                 if not self._graph.deps[name]:
                     self._mark_ready(bi, name)
@@ -466,6 +488,10 @@ class _Scheduler:
                 cap = self._graph.nodes[name].max_inflight
                 while q and self._node_inflight[name] < cap:
                     bi = q.popleft()
+                    # batch 可能在入队后被作废(某 source 回哨兵)——跳过:不提交作废 batch 的下游,
+                    # 且其 ctx/status 可能已被 _retire_if_drained 清掉,再 _submit 会 KeyError。
+                    if bi in self._void or bi not in self._status:
+                        continue
                     if self._status[bi][name].phase != "ready":
                         continue
                     self._submit(bi, self._graph.nodes[name])
@@ -497,6 +523,7 @@ class _Scheduler:
             refs=refs, collect_fn=future.collect_fn,
         )
         self._node_inflight[spec.name] += 1
+        self._batch_inflight[bi] = self._batch_inflight.get(bi, 0) + 1
 
         call = _InflightCall(batch_idx=bi, node_name=spec.name, refs=list(refs))
         for ref in refs:
@@ -516,12 +543,39 @@ class _Scheduler:
             raw = ray.get(call.refs)
             value = pending.collect_fn(spec.module, raw) if pending.collect_fn else raw
 
+        # per-batch / per-node in-flight 记账(哨兵与正常路径都要减,否则收尾判据错)。
+        # _submit 保证已先 +1,故 bi 必在字典中——缺失是真 bug,让它 KeyError 暴露而非静默兜底。
+        self._node_inflight[name] -= 1
+        self._batch_inflight[bi] -= 1
+        st.phase = "done"
+        st.pending = None
+
+        # 自驱动 1-ahead 门控:source 节点完成(不论出数据还是哨兵)即消 _src_left;本 batch 的 source 全
+        # 完成 → 从 _src_left 移除,放行 _admit_batches 下一批。放在两个分支之前,确保哨兵路径也解锁。
+        if self._self_driven and bi in self._src_left and not self._graph.deps[name]:
+            self._src_left[bi] -= 1
+            if self._src_left[bi] <= 0:
+                self._src_left.pop(bi, None)
+
+        # ── 流式 source 枯竭:该 source 节点的 run 抛 StopIteration，RunnerActor 已转成哨兵 ──
+        # 语义 = 「任一 source 枯竭 → 全图停」(与 driver 侧 _next_input_row 任一迭代器 StopIteration
+        # 即停完全对称)。做两件事:① 置枯竭 → _admit_batches 不再 admit 新 batch;② 作废本 batch——
+        # 它是「乐观 admit」出来的、上游已无数据,不该产出结果、也不该往下游 dispatch。已在途的兄弟
+        # 节点调用完成后同样落进 void 分支被清理,batch 收尾靠 _batch_inflight 归零。
+        if isinstance(value, _SourceExhausted):
+            self._source_exhausted = True
+            self._void.add(bi)
+            self._retire_if_drained(bi)
+            return
+
+        # 本 batch 已被作废(某 source 先枯竭):不再产出/下推,仅做 in-flight 收尾。
+        if bi in self._void:
+            self._retire_if_drained(bi)
+            return
+
         _validate_output(spec, value)
 
         self._ctx[bi][name] = value if spec.num_outputs > 1 else (value,)
-        st.phase = "done"
-        st.pending = None
-        self._node_inflight[name] -= 1
 
         for child in self._graph.consumers[name]:
             if self._all_deps_done(bi, child):
@@ -537,6 +591,21 @@ class _Scheduler:
             # 流式:完成的 batch ctx/status 即刻释放(不全程持有 → TB 级不堆内存)
             self._ctx.pop(bi, None)
             self._status.pop(bi, None)
+            self._batch_inflight.pop(bi, None)
+
+    def _retire_if_drained(self, bi: int) -> None:
+        """作废 batch 的收尾:等它所有在途调用回来(_batch_inflight 归零)再释放状态。
+
+        不能在遇到哨兵的瞬间就 pop——同一 batch 的兄弟 source/节点可能仍在途(fan-out 并行 admit),
+        它们的 ObjectRef 还在 _outstanding 里、完成时要能查到自己的 ctx/status。故按未完成调用计数收尾。
+        """
+        if self._batch_inflight.get(bi, 0) > 0:
+            return
+        self._live.discard(bi)
+        self._ctx.pop(bi, None)
+        self._status.pop(bi, None)
+        self._batch_inflight.pop(bi, None)
+        self._src_left.pop(bi, None)
 
     def _release_upstream(self, bi: int, name: str) -> None:
         for dep in self._graph.deps[name]:

--- a/rayorch/dag_new_pipeline.py
+++ b/rayorch/dag_new_pipeline.py
@@ -27,7 +27,7 @@ from abc import ABC, abstractmethod
 from collections import deque
 from dataclasses import dataclass
 import inspect
-from typing import Any, Deque, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Deque, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
 
 import ray
 
@@ -334,27 +334,45 @@ class _InflightCall:
 
 
 class _Scheduler:
-    """``ray.wait``-driven event loop for :class:`DagExecutor`."""
+    """``ray.wait``-driven event loop for :class:`DagExecutor`.
+
+    **流式驱动(不预知 batch 总数)**：input_columns 的每个 value 只需是 *iterable*（list 或任意迭代器/
+    生成器）。调度器按 ``max_batches_inflight`` 边拉边 admit——从每个 input_key 的迭代器**同步取一批**
+    （所有 key 都还有下一个才 admit 新 batch；任一耗尽即源枯竭）。终止条件是「源枯竭 且 in-flight 清空」，
+    **不依赖 len(columns)**。这让 hydp-dataflow 的「有状态流式 reader」(每次 run 吐一 batch、迭代器枯竭即停)
+    天然可跑，TB 级/未知长度源不 OOM、不预扫。``_ctx``/``_status`` 按 batch 懒建、完成即释放。
+
+    向后兼容：value 传 list 时 ``iter(list)`` 即可，老行为不变（同步同长、结果按 admit 序返回）。
+    """
 
     def __init__(
         self,
         graph: CompiledGraph,
-        input_columns: Dict[str, Sequence[Any]],
+        input_columns: Dict[str, "Iterable[Any]"],
         max_batches_inflight: int,
     ) -> None:
         self._graph = graph
         self._max_inflight = max(1, int(max_batches_inflight))
-        self._n_batches = _validate_columns(graph, input_columns)
 
-        self._ctx: List[Dict[str, tuple]] = [
-            {key: (input_columns[key][i],) for key in graph.input_keys}
-            for i in range(self._n_batches)
-        ]
-        self._status: List[Dict[str, _NodeStatus]] = [
-            {name: _NodeStatus() for name in graph.topo_order}
-            for _ in range(self._n_batches)
-        ]
-        self._results: List[Any] = [None] * self._n_batches
+        # input_keys 校验(只查键集一致，不再要求等长/已知长度）
+        expected = set(graph.input_keys)
+        if set(input_columns.keys()) != expected:
+            raise ValueError(
+                f"input keys mismatch: expected {graph.input_keys}, "
+                f"got {tuple(input_columns.keys())}"
+            )
+        if not graph.input_keys:
+            raise ValueError("input columns cannot be empty")
+        # 每个 input_key 一个迭代器（list/生成器/任意 iterable 统一 iter()）
+        self._iters: Dict[str, "Iterator[Any]"] = {
+            k: iter(v) for k, v in input_columns.items()
+        }
+        self._source_exhausted = False
+
+        # 按 batch 懒建(dict[bi] 而非 list[N])——不预知总数、完成即可释放
+        self._ctx: Dict[int, Dict[str, tuple]] = {}
+        self._status: Dict[int, Dict[str, _NodeStatus]] = {}
+        self._results: Dict[int, Any] = {}
 
         self._ready_q: Dict[str, Deque[int]] = {n: deque() for n in graph.topo_order}
         self._node_inflight: Dict[str, int] = {n: 0 for n in graph.topo_order}
@@ -378,7 +396,21 @@ class _Scheduler:
                 self._on_complete(call)
             self._admit_batches()
             self._dispatch()
-        return self._results
+        # 结果按 admit 序(batch idx 升序)还原成 list
+        return [self._results[i] for i in sorted(self._results)]
+
+    def _next_input_row(self) -> "Dict[str, Any] | None":
+        """从每个 input_key 的迭代器同步取一批;任一耗尽 → 源枯竭,返回 None。"""
+        if self._source_exhausted:
+            return None
+        row: Dict[str, Any] = {}
+        for key, it in self._iters.items():
+            try:
+                row[key] = next(it)
+            except StopIteration:
+                self._source_exhausted = True
+                return None
+        return row
 
     def _drain_completed(self) -> List[_InflightCall]:
         ready, _ = ray.wait(list(self._outstanding), num_returns=1)
@@ -404,14 +436,20 @@ class _Scheduler:
         return calls
 
     def _admit_batches(self) -> None:
-        while (self._next_batch < self._n_batches
-               and len(self._live) < self._max_inflight):
+        # 迭代器驱动:边拉边 admit,拿不到(源枯竭)就停;不依赖 len(columns)。
+        while len(self._live) < self._max_inflight:
+            row = self._next_input_row()
+            if row is None:
+                break
             bi = self._next_batch
             self._next_batch += 1
             self._live.add(bi)
+            self._ctx[bi] = {key: (row[key],) for key in self._graph.input_keys}
+            self._status[bi] = {name: _NodeStatus() for name in self._graph.topo_order}
             for name in self._graph.topo_order:
                 if not self._graph.deps[name]:
                     self._mark_ready(bi, name)
+
 
     def _mark_ready(self, bi: int, name: str) -> None:
         st = self._status[bi][name]
@@ -497,6 +535,9 @@ class _Scheduler:
                 self._ctx[bi], self._graph.graph_outputs,
             )
             self._live.discard(bi)
+            # 流式:完成的 batch ctx/status 即刻释放(不全程持有 → TB 级不堆内存)
+            self._ctx.pop(bi, None)
+            self._status.pop(bi, None)
 
     def _release_upstream(self, bi: int, name: str) -> None:
         for dep in self._graph.deps[name]:
@@ -527,7 +568,7 @@ class DagExecutor(Executor):
     def execute(
         self,
         graph: CompiledGraph,
-        columns: Dict[str, Sequence[Any]],
+        columns: Dict[str, "Iterable[Any]"],
     ) -> List[Any]:
         return _Scheduler(graph, columns, self.max_batches_inflight).run()
 

--- a/rayorch/dag_new_pipeline.py
+++ b/rayorch/dag_new_pipeline.py
@@ -450,7 +450,6 @@ class _Scheduler:
                 if not self._graph.deps[name]:
                     self._mark_ready(bi, name)
 
-
     def _mark_ready(self, bi: int, name: str) -> None:
         st = self._status[bi][name]
         if st.phase != "waiting":

--- a/rayorch/dispatch_mode.py
+++ b/rayorch/dispatch_mode.py
@@ -6,6 +6,8 @@ from typing import Any, Callable, Dict, Mapping, Sequence, Tuple, Union, List
 
 import ray
 
+from .container_ops import is_sliceable, uni_concat, uni_slice
+
 
 class Dispatch(Enum):
     BROADCAST = auto()
@@ -64,7 +66,6 @@ def collect_identity(rm, output):
 def _is_shardable(x: Any) -> bool:
     # 可当 batch 切分的容器:list/tuple + DataFrame/arrow/numpy(见 container_ops.is_sliceable)。
     # 表 + 多模态 object 统一(hydp-dataflow §4.5 坐实);其余(标量/ObjectRef 另处理)一律广播。
-    from .container_ops import is_sliceable
     return is_sliceable(x)
 
 
@@ -131,7 +132,6 @@ def dispatch_shard_all_args_mod(rm, *args, **kwargs):
     def shard_seq(seq):
         if ranges is None:
             raise ValueError("Internal error: ranges is None for shardable sequence input.")
-        from .container_ops import uni_slice
         return [uni_slice(seq, s, e) for (s, e) in ranges]   # arrow .slice / 其余 [s:e]
 
     def shard_ref(ref: ray.ObjectRef):
@@ -214,10 +214,8 @@ def collect_concat(rm, outputs):
 
         # 0) DataFrame/arrow/numpy 等非 list/tuple 的可切片容器:直接按类型拼(container_ops)。
         #    (表 + 多模态 object 统一;list/tuple 仍走下面原路径,向后兼容)
-        if not isinstance(x0, (list, tuple, dict)):
-            from .container_ops import is_sliceable, uni_concat
-            if is_sliceable(x0):
-                return uni_concat(seq)
+        if not isinstance(x0, (list, tuple, dict)) and is_sliceable(x0):
+            return uni_concat(seq)
 
         # 1) dict：对每个 key 递归 merge
         if isinstance(x0, dict):

--- a/rayorch/dispatch_mode.py
+++ b/rayorch/dispatch_mode.py
@@ -62,9 +62,10 @@ def collect_identity(rm, output):
 # dispatch_mode.py (append)
 
 def _is_shardable(x: Any) -> bool:
-    # 只把 list/tuple 当作可切片 batch；其他一律广播
-    # 如果你还想支持 numpy/torch batch，可在这里扩展
-    return isinstance(x, (list, tuple))
+    # 可当 batch 切分的容器:list/tuple + DataFrame/arrow/numpy(见 container_ops.is_sliceable)。
+    # 表 + 多模态 object 统一(hydp-dataflow §4.5 坐实);其余(标量/ObjectRef 另处理)一律广播。
+    from .container_ops import is_sliceable
+    return is_sliceable(x)
 
 
 def _is_object_ref(x: Any) -> bool:
@@ -130,7 +131,8 @@ def dispatch_shard_all_args_mod(rm, *args, **kwargs):
     def shard_seq(seq):
         if ranges is None:
             raise ValueError("Internal error: ranges is None for shardable sequence input.")
-        return [seq[s:e] for (s, e) in ranges]
+        from .container_ops import uni_slice
+        return [uni_slice(seq, s, e) for (s, e) in ranges]   # arrow .slice / 其余 [s:e]
 
     def shard_ref(ref: ray.ObjectRef):
         return [ShardedObjectRef(ref=ref, shard_idx=i, num_shards=ws) for i in range(ws)]
@@ -209,6 +211,13 @@ def collect_concat(rm, outputs):
             return None
 
         x0 = seq[0]
+
+        # 0) DataFrame/arrow/numpy 等非 list/tuple 的可切片容器:直接按类型拼(container_ops)。
+        #    (表 + 多模态 object 统一;list/tuple 仍走下面原路径,向后兼容)
+        if not isinstance(x0, (list, tuple, dict)):
+            from .container_ops import is_sliceable, uni_concat
+            if is_sliceable(x0):
+                return uni_concat(seq)
 
         # 1) dict：对每个 key 递归 merge
         if isinstance(x0, dict):

--- a/rayorch/ray_module.py
+++ b/rayorch/ray_module.py
@@ -15,6 +15,7 @@ class RunOp(Protocol[INITP, RUNP, R]):
 import ray
 
 from .dispatch_mode import DispatchMode, ShardedObjectRef, get_predefined_dispatch_fn
+from .container_ops import is_sliceable, uni_slice
 from .env_registry import EnvRegistry
 
 # from image_class import ImageLoadOp, ImageSaveOP
@@ -40,7 +41,6 @@ class RunnerActor:
 
     def run(self, args, kwargs, meta=None):
         def _slice_for_replica(seq, shard_idx: int, num_shards: int):
-            from .container_ops import uni_slice
             n = len(seq)
             base = n // num_shards
             rem = n % num_shards
@@ -52,7 +52,6 @@ class RunnerActor:
             # ShardedObjectRef: core path for SHARD_* dispatch — each replica
             # resolves the shared ref and slices its own partition.
             if isinstance(x, ShardedObjectRef):
-                from .container_ops import is_sliceable
                 resolved = ray.get(x.ref)
                 if is_sliceable(resolved):
                     return _slice_for_replica(resolved, x.shard_idx, x.num_shards)

--- a/rayorch/ray_module.py
+++ b/rayorch/ray_module.py
@@ -24,6 +24,31 @@ from .env_registry import EnvRegistry
 
 
 # --------------------------
+# 流式 source 枯竭哨兵
+# --------------------------
+class _SourceExhausted:
+    """Sentinel: a source node's ``run`` raised ``StopIteration`` (a stateful
+    stream reader, e.g. ``return next(self._it)``, hit end-of-stream).
+
+    :class:`RunnerActor` catches that ``StopIteration`` and returns this sentinel
+    instead of letting it surface as a ``RayTaskError``; the DAG scheduler
+    (:class:`~rayorch.dag_new_pipeline._Scheduler`) recognizes it to stop
+    admitting new batches. **Zero operator coupling**: an op just does
+    ``return next(self._it)`` — it never imports or references this sentinel.
+    Identity survives Ray (de)serialization via ``isinstance`` (the class is
+    referenced by module path, not object identity).
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return "<SOURCE_EXHAUSTED>"
+
+
+SOURCE_EXHAUSTED = _SourceExhausted()
+
+
+# --------------------------
 # Actor：运行时不要 Generic/ParamSpec, 否则会报serialize的错误
 # --------------------------
 @ray.remote
@@ -76,7 +101,14 @@ class RunnerActor:
         with dev_nvtx_range:
             resolved_args = _resolve_refs(args)
             resolved_kwargs = _resolve_refs(kwargs)
-            return self.op.run(*resolved_args, **resolved_kwargs)
+            try:
+                return self.op.run(*resolved_args, **resolved_kwargs)
+            except StopIteration:
+                # Stateful stream reader hit end-of-stream (`return next(self._it)`).
+                # Surface as a sentinel value, not a RayTaskError, so the DAG
+                # scheduler can stop admitting batches. StopIteration must not
+                # escape a remote task anyway (it would become a RayTaskError).
+                return SOURCE_EXHAUSTED
 
 
 def _infer_num_outputs(op_cls: type) -> int:

--- a/rayorch/ray_module.py
+++ b/rayorch/ray_module.py
@@ -40,19 +40,21 @@ class RunnerActor:
 
     def run(self, args, kwargs, meta=None):
         def _slice_for_replica(seq, shard_idx: int, num_shards: int):
+            from .container_ops import uni_slice
             n = len(seq)
             base = n // num_shards
             rem = n % num_shards
             start = shard_idx * base + min(shard_idx, rem)
             end = start + base + (1 if shard_idx < rem else 0)
-            return seq[start:end]
+            return uni_slice(seq, start, end)   # arrow .slice / 其余 [s:e]
 
         def _resolve_refs(x):
             # ShardedObjectRef: core path for SHARD_* dispatch — each replica
             # resolves the shared ref and slices its own partition.
             if isinstance(x, ShardedObjectRef):
+                from .container_ops import is_sliceable
                 resolved = ray.get(x.ref)
-                if isinstance(resolved, (list, tuple)):
+                if is_sliceable(resolved):
                     return _slice_for_replica(resolved, x.shard_idx, x.num_shards)
                 return resolved
             # Raw ObjectRef: in DAG runtime the scheduler materializes values

--- a/test/test_selfdriven_source.py
+++ b/test/test_selfdriven_source.py
@@ -1,0 +1,363 @@
+"""自驱动 source(有状态流式 reader)+ StopIteration 哨兵驱动终止 —— 正确性 / 边界 / 时间账。
+
+**这是什么能力**:一个算子的 ``run`` 自己 ``return next(self._it)`` 从内部迭代器(如
+``ray.data.read_parquet(uri).iter_batches()``)流式吐 batch,迭代器枯竭时 ``run`` 抛 ``StopIteration``。
+把这样的算子放进 ``CompiledGraph`` 的 **root 节点**(``deps==()``、无 ``input_keys``),``DagExecutor`` 就
+**乐观 admit、靠哨兵终止**——不预知 batch 总数、TB 级源不 OOM,多个无依赖 reader 各自 actor **并行读**。
+
+**算子零耦合**:reader 只写 ``return next(self._it)``,不 import 任何引擎符号;``StopIteration → SOURCE_EXHAUSTED``
+的转换收在 :class:`RunnerActor`,哨兵识别收在 ``_Scheduler``(见 ``docs/dag_new_pipeline_architecture.md``)。
+
+────────────────────────── API 用法(最小示例) ──────────────────────────
+    class StreamReader:                       # 有状态 reader:零引擎耦合
+        def __init__(self, uri):
+            self._it = iter(ray.data.read_parquet(uri).iter_batches(batch_size=1000))
+        def run(self):                         # root 节点 run 无参;枯竭时 next() 自然抛 StopIteration
+            return next(self._it)
+
+    r = RayModule(StreamReader, replicas=1, max_inflight=4).pre_init(uri)
+    graph = CompiledGraph(
+        nodes={"read": NodeSpec("read", r, args=(), kw_args={}, max_inflight=4, num_outputs=1), ...},
+        ..., input_keys=())                    # ★ 空 input_keys = 纯自驱动图
+    out = DagExecutor(max_batches_inflight=4).execute(graph, {})   # 无需喂 columns
+────────────────────────────────────────────────────────────────────────
+
+跑法:``python -m pytest test/test_selfdriven_source.py -q``(``-s`` 看 bench 时间账)。
+"""
+from __future__ import annotations
+
+import time
+
+import ray
+
+from rayorch.dag_new_pipeline import CompiledGraph, DagExecutor, NodeSpec, PipeRef
+from rayorch.ray_module import RayModule, SOURCE_EXHAUSTED, _SourceExhausted
+
+
+# --------------------------------------------------------------------------- #
+# 可 import 的算子(Ray by-reference 还原需模块级可 import;零引擎耦合)
+# --------------------------------------------------------------------------- #
+class _ListReader:
+    """有状态 reader:init 持一个 list 的迭代器,每次 run next() 吐一 batch,枯竭抛 StopIteration。
+
+    真实场景里 ``self._it`` 是 ``iter(ray.data.read_*(uri).iter_batches())``;这里用 list 模拟,
+    语义一致(``next()`` + 自然 ``StopIteration``),不依赖 ray.data、测试快且确定。
+    """
+
+    def __init__(self, values, sleep_s: float = 0.0):
+        self._it = iter(values)
+        self._sleep = sleep_s
+
+    def run(self):
+        if self._sleep:
+            time.sleep(self._sleep)
+        return next(self._it)                  # 枯竭 → StopIteration(Python 原生,零引擎耦合)
+
+
+class _TsReader:
+    """记 (enter, exit) 绝对时间戳的 reader —— 证明多 source 真并行(执行区间重叠)用。"""
+
+    def __init__(self, n_batches: int, sleep_s: float):
+        self._it = iter(range(n_batches))
+        self._sleep = sleep_s
+
+    def run(self):
+        t0 = time.perf_counter()
+        time.sleep(self._sleep)
+        next(self._it)                         # 枯竭即停
+        return [[t0, time.perf_counter()]]
+
+
+class _Double:
+    def run(self, x):
+        return [v * 2 for v in x]
+
+
+class _MergePair:
+    """fan-in:两路逐元素打包 tuple(看是否对齐/串位)。"""
+    def run(self, a, b):
+        return [(x, y) for x, y in zip(a, b)]
+
+
+class _Collect:
+    """收两路时间戳区间成 [ra_iv, rb_iv]。"""
+    def run(self, a, b):
+        return [[a[0], b[0]]]
+
+
+class _SleepStage:
+    """流水线阶段:sleep 固定时长透传。类属性 S 可调(bench 用)。"""
+    S = 0.1
+
+    def run(self, x):
+        time.sleep(self.S)
+        return x
+
+
+def _cleanup(*modules: RayModule) -> None:
+    for m in modules:
+        for actor in getattr(m, "actors", []):
+            try:
+                ray.kill(actor)
+            except Exception:
+                pass
+
+
+def _rm(cls, *init, inflight=4):
+    return RayModule(cls, replicas=1, max_inflight=inflight, num_outputs=1).pre_init(*init)
+
+
+def _single_graph(reader_module):
+    """[read]→[double]→out,无 input_keys(纯自驱动)。"""
+    dmod = _rm(_Double)
+    g = CompiledGraph(
+        nodes={
+            "read": NodeSpec(name="read", module=reader_module, args=(), kw_args={}, max_inflight=4, num_outputs=1),
+            "double": NodeSpec(name="double", module=dmod, args=(PipeRef(node="read", index=0),), kw_args={}, max_inflight=4, num_outputs=1),
+        },
+        topo_order=("read", "double"), deps={"read": (), "double": ("read",)},
+        consumers={"read": ("double",), "double": ()},
+        graph_outputs=(PipeRef(node="double", index=0),), input_keys=())
+    return g, dmod
+
+
+def _fanin_graph(ra_module, rb_module, merge_cls=_MergePair):
+    """a=[ra] b=[rb] → Merge(a,b),两自驱动 source 无依赖(可并行);无 input_keys。"""
+    mm = _rm(merge_cls)
+    g = CompiledGraph(
+        nodes={
+            "ra": NodeSpec(name="ra", module=ra_module, args=(), kw_args={}, max_inflight=4, num_outputs=1),
+            "rb": NodeSpec(name="rb", module=rb_module, args=(), kw_args={}, max_inflight=4, num_outputs=1),
+            "merge": NodeSpec(name="merge", module=mm, args=(), kw_args={"a": PipeRef(node="ra", index=0), "b": PipeRef(node="rb", index=0)}, max_inflight=4, num_outputs=1),
+        },
+        topo_order=("ra", "rb", "merge"),
+        deps={"ra": (), "rb": (), "merge": ("ra", "rb")},
+        consumers={"ra": ("merge",), "rb": ("merge",), "merge": ()},
+        graph_outputs=(PipeRef(node="merge", index=0),), input_keys=())
+    return g, mm
+
+
+# =========================================================================== #
+# 正确性
+# =========================================================================== #
+def test_single_selfdriven_source_runs_and_stops():
+    """单自驱动 source:N 批全产出、数据对、迭代器枯竭即停(不预知 N)。"""
+    ray.init(ignore_reinit_error=True, num_cpus=4)
+    ra = _rm(_ListReader, [[0, 1, 2], [3, 4, 5], [6, 7, 8]])   # 3 batch
+    g, dmod = _single_graph(ra)
+    try:
+        out = DagExecutor(max_batches_inflight=4).execute(g, {})
+        assert out == [[0, 2, 4], [6, 8, 10], [12, 14, 16]]
+    finally:
+        _cleanup(ra, dmod)
+        ray.shutdown()
+
+
+def test_empty_source_yields_nothing():
+    """空 source(reader 立即 StopIteration)→ 空结果,不崩不挂。"""
+    ray.init(ignore_reinit_error=True, num_cpus=4)
+    ra = _rm(_ListReader, [])
+    g, dmod = _single_graph(ra)
+    try:
+        assert DagExecutor(max_batches_inflight=4).execute(g, {}) == []
+    finally:
+        _cleanup(ra, dmod)
+        ray.shutdown()
+
+
+def test_inflight_one_no_deadlock():
+    """inflight=1:1-ahead admit 门控在最小并发下仍推进,不死锁。"""
+    ray.init(ignore_reinit_error=True, num_cpus=4)
+    ra = _rm(_ListReader, [[0], [1], [2]], inflight=1)
+    g, dmod = _single_graph(ra)
+    try:
+        assert DagExecutor(max_batches_inflight=1).execute(g, {}) == [[0], [2], [4]]
+    finally:
+        _cleanup(ra, dmod)
+        ray.shutdown()
+
+
+def test_backward_compat_driver_list_inputs():
+    """向后兼容:非空 input_keys(driver 侧喂 list)完全走老路径,行为不变(哨兵/门控不触发)。"""
+    ray.init(ignore_reinit_error=True, num_cpus=4)
+    dmod = _rm(_Double)
+    g = CompiledGraph(
+        nodes={"d": NodeSpec(name="d", module=dmod, args=(PipeRef(node="__input__x", index=0),), kw_args={}, max_inflight=4, num_outputs=1)},
+        topo_order=("d",), deps={"d": ()}, consumers={"d": ()},
+        graph_outputs=(PipeRef(node="d", index=0),), input_keys=("__input__x",))
+    try:
+        assert DagExecutor(max_batches_inflight=4).execute(g, {"__input__x": [[1, 2], [3, 4]]}) == [[2, 4], [6, 8]]
+    finally:
+        _cleanup(dmod)
+        ray.shutdown()
+
+
+# =========================================================================== #
+# ★ Corner cases:多 source 不等长 / 一路先枯竭另一路在途
+# =========================================================================== #
+def test_unequal_length_stops_at_shortest_and_aligns():
+    """不等长 fan-in(A=5, B=3):停在最短(3);抢先多读的 A[3]/A[4] 被丢弃、产出严格对齐不串位。"""
+    ray.init(ignore_reinit_error=True, num_cpus=4)
+    ra = _rm(_ListReader, [[i] for i in range(5)])            # A: [0][1][2][3][4]
+    rb = _rm(_ListReader, [[100 + i] for i in range(3)])      # B: [100][101][102]
+    g, mm = _fanin_graph(ra, rb)
+    try:
+        out = DagExecutor(max_batches_inflight=4).execute(g, {})
+        # 停在短的(3),逐批严格对齐 (A[i], B[i]),A 多读的两批不产出、不串位
+        assert out == [[(0, 100)], [(1, 101)], [(2, 102)]]
+    finally:
+        _cleanup(ra, rb, mm)
+        ray.shutdown()
+
+
+def test_one_source_exhausts_while_sibling_inflight():
+    """竞态:rb 立即枯竭(0 批),ra 慢(在途 sleep)。作废 batch 须等在途的 ra 回来才收尾,不崩不挂、无产出。
+
+    这逼出 `_retire_if_drained` 的在途路径:哨兵先到 → batch 入 `_void` 但 `_batch_inflight>0` 不释放 →
+    ra 完成回来走 void 分支收尾。若收尾错(提前 pop / KeyError / 挂起)这条会崩或超时。
+    """
+    ray.init(ignore_reinit_error=True, num_cpus=4)
+    ra = _rm(_ListReader, [[i] for i in range(5)], 0.4)   # 慢、在途(第3个 init 参数 = sleep_s)
+    rb = _rm(_ListReader, [])                                     # 立即枯竭
+    g, mm = _fanin_graph(ra, rb)
+    try:
+        t = time.perf_counter()
+        out = DagExecutor(max_batches_inflight=4).execute(g, {})
+        dt = time.perf_counter() - t
+        assert out == []                    # 一路空 → 全图 0 产出
+        assert dt < 10.0                    # 不挂(宽松上界,真挂会撞 pytest 超时)
+    finally:
+        _cleanup(ra, rb, mm)
+        ray.shutdown()
+
+
+def test_shorter_source_slow_still_aligns():
+    """反向竞态:ra 短(2 批)、rb 长且慢(5 批 sleep)→ 停在 2,rb 抢先多读丢弃、对齐不串。"""
+    ray.init(ignore_reinit_error=True, num_cpus=4)
+    ra = _rm(_ListReader, [[i] for i in range(2)])
+    rb = _rm(_ListReader, [[100 + i] for i in range(5)], 0.2)   # 长且慢(第3个 init 参数 = sleep_s)
+    g, mm = _fanin_graph(ra, rb)
+    try:
+        out = DagExecutor(max_batches_inflight=4).execute(g, {})
+        assert out == [[(0, 100)], [(1, 101)]]
+    finally:
+        _cleanup(ra, rb, mm)
+        ray.shutdown()
+
+
+def test_three_sources_unequal():
+    """3-source fan-in 不等长(5/2/4):停在最短(2)。"""
+    ray.init(ignore_reinit_error=True, num_cpus=4)
+    ra = _rm(_ListReader, [[i] for i in range(5)])
+    rb = _rm(_ListReader, [[100 + i] for i in range(2)])
+    rc = _rm(_ListReader, [[200 + i] for i in range(4)])
+
+    class Merge3:
+        def run(self, a, b, c):
+            return [(x, y, z) for x, y, z in zip(a, b, c)]
+    mm = _rm(Merge3)
+    g = CompiledGraph(
+        nodes={
+            "ra": NodeSpec(name="ra", module=ra, args=(), kw_args={}, max_inflight=4, num_outputs=1),
+            "rb": NodeSpec(name="rb", module=rb, args=(), kw_args={}, max_inflight=4, num_outputs=1),
+            "rc": NodeSpec(name="rc", module=rc, args=(), kw_args={}, max_inflight=4, num_outputs=1),
+            "merge": NodeSpec(name="merge", module=mm, args=(), kw_args={"a": PipeRef(node="ra", index=0), "b": PipeRef(node="rb", index=0), "c": PipeRef(node="rc", index=0)}, max_inflight=4, num_outputs=1),
+        },
+        topo_order=("ra", "rb", "rc", "merge"),
+        deps={"ra": (), "rb": (), "rc": (), "merge": ("ra", "rb", "rc")},
+        consumers={"ra": ("merge",), "rb": ("merge",), "rc": ("merge",), "merge": ()},
+        graph_outputs=(PipeRef(node="merge", index=0),), input_keys=())
+    try:
+        out = DagExecutor(max_batches_inflight=4).execute(g, {})
+        assert out == [[(0, 100, 200)], [(1, 101, 201)]]
+    finally:
+        _cleanup(ra, rb, rc, mm)
+        ray.shutdown()
+
+
+# =========================================================================== #
+# 哨兵语义
+# =========================================================================== #
+def test_sentinel_identity_survives_ray_serialization():
+    """哨兵 SOURCE_EXHAUSTED 跨 Ray 序列化后 isinstance 仍 True(按模块路径引用,非对象 identity)。"""
+    ray.init(ignore_reinit_error=True, num_cpus=2)
+
+    @ray.remote
+    def _echo(x):
+        return x
+    try:
+        got = ray.get(_echo.remote(SOURCE_EXHAUSTED))
+        assert isinstance(got, _SourceExhausted)
+    finally:
+        ray.shutdown()
+
+
+# =========================================================================== #
+# ★ 时间账 bench:多 source 真并行 + 自驱动流水线重叠(带断言)
+# =========================================================================== #
+def test_multisource_reads_in_parallel():
+    """★两个无依赖 reader 各自 actor → 同批 ra/rb 执行区间**重叠**(直接证据,非 wall 差值)。
+
+    直接看执行区间:若两 actor 同时跑,同批 ra/rb 的 [enter,exit] 重叠 ≈ 满 sleep;接力串行则 ≈ 0。
+    """
+    ray.init(ignore_reinit_error=True, num_cpus=8)
+    S, NB = 0.3, 4
+    ra = _rm(_TsReader, NB, S)
+    rb = _rm(_TsReader, NB, S)
+    g, mm = _fanin_graph(ra, rb, merge_cls=_Collect)
+    try:
+        batches = DagExecutor(max_batches_inflight=4).execute(g, {})
+        ivs = [pair for b in batches for pair in b]
+        assert len(ivs) == NB
+        overlaps = [min(a[1], b[1]) - max(a[0], b[0]) for a, b in ivs]
+        n_par = sum(1 for o in overlaps if o > 0.5 * S)
+        print(f"\n[bench] 多 source 真并行: {n_par}/{NB} 批 ra/rb 区间重叠 (overlaps={[round(o,2) for o in overlaps]}, S={S})")
+        assert n_par == NB, f"多 source 未并行: overlaps={overlaps}"
+    finally:
+        _cleanup(ra, rb, mm)
+        ray.shutdown()
+
+
+def test_selfdriven_pipeline_overlap():
+    """★自驱动 source + 3 阶段线性下游,inflight 流水线重叠显著快于串行。
+
+    信号 >> 噪声的配置:N=40 batch、K=3 阶段、每阶段 S=0.1s。overlap 收益随 N 线性涨(省 ≈(K-1)/K·N·K·S
+    量级),actor 冷启是固定常数——N 大到收益(理论省 ≈ 2·N·S = 8s)远压过冷启噪声(~1s)。inflight 上限取
+    K+1=4(=流水线深度,不超订 8 CPU)。断言加速 > 1.8×(实测 ~2.4×,理论上限 K=3×)。
+    """
+    ray.init(ignore_reinit_error=True, num_cpus=8)
+    N, S, INFLIGHT = 40, 0.1, 4
+    _SleepStage.S = S
+
+    def build(inflight):
+        r = _rm(_ListReader, [[i] for i in range(N)], inflight=inflight)
+        s1 = _rm(_SleepStage, inflight=inflight)
+        s2 = _rm(_SleepStage, inflight=inflight)
+        s3 = _rm(_SleepStage, inflight=inflight)
+        g = CompiledGraph(
+            nodes={
+                "r": NodeSpec(name="r", module=r, args=(), kw_args={}, max_inflight=inflight, num_outputs=1),
+                "s1": NodeSpec(name="s1", module=s1, args=(PipeRef(node="r", index=0),), kw_args={}, max_inflight=inflight, num_outputs=1),
+                "s2": NodeSpec(name="s2", module=s2, args=(PipeRef(node="s1", index=0),), kw_args={}, max_inflight=inflight, num_outputs=1),
+                "s3": NodeSpec(name="s3", module=s3, args=(PipeRef(node="s2", index=0),), kw_args={}, max_inflight=inflight, num_outputs=1),
+            },
+            topo_order=("r", "s1", "s2", "s3"),
+            deps={"r": (), "s1": ("r",), "s2": ("s1",), "s3": ("s2",)},
+            consumers={"r": ("s1",), "s1": ("s2",), "s2": ("s3",), "s3": ()},
+            graph_outputs=(PipeRef(node="s3", index=0),), input_keys=())
+        return g, (r, s1, s2, s3)
+
+    g1, m1 = build(1)
+    gN, mN = build(INFLIGHT)
+    try:
+        t = time.perf_counter(); o1 = DagExecutor(max_batches_inflight=1).execute(g1, {}); t1 = time.perf_counter() - t
+        t = time.perf_counter(); oN = DagExecutor(max_batches_inflight=INFLIGHT).execute(gN, {}); tN = time.perf_counter() - t
+        speedup = t1 / tN
+        print(f"\n[bench] 自驱动流水线重叠 (N={N}, K=3阶段, S={S}s): "
+              f"serial(inflight=1) {t1:.2f}s → overlap(inflight={INFLIGHT}) {tN:.2f}s | "
+              f"加速 {speedup:.2f}× (理论上限3×) | 省 {t1-tN:.2f}s (>> 冷启~1s)")
+        assert len(o1) == len(oN) == N
+        assert speedup > 1.8, f"跨 batch 未充分重叠: serial {t1:.2f}s vs overlap {tN:.2f}s (加速仅 {speedup:.2f}×)"
+    finally:
+        _cleanup(*m1, *mN)
+        ray.shutdown()


### PR DESCRIPTION
 ## What

  两个正交能力,让 `DagExecutor` 能承接「表 + 多模态 object 统一」与「流式 / 未知长度源」:

  ### 1. batch 单元放宽:list-only → 任意可切片容器
  原本 `_is_shardable` / `_submit` / `_validate_output` / `collect_concat` 硬编码 `isinstance(list/tuple)`,
  DataFrame / arrow / numpy batch 进不来。新增 `container_ops.py` 收口两个 helper:
  - `uni_slice(x, s, e)` —— 位置切片(arrow 用 `.slice`,其余 `x[s:e]`)
  - `uni_concat(parts)` —— 按类型分派拼接(list/tuple/DataFrame/Table/ndarray)

  鸭子类型判定,**不硬依赖 pandas/pyarrow/numpy**(按需惰性 import),保持依赖轻。四处守卫 +
  `_slice_for_replica` 统一指向 helper。新增一种容器 = 分派表加一支。

  ### 2. `_Scheduler` 迭代器驱动:不预知 batch 总数
  原 scheduler 靠 `len(columns)` 预知 `n_batches`、预建 `list[N]` 的 `_ctx/_status/_results`。改为:
  - 从各 input_key 迭代器**同步取一批**,任一耗尽即源枯竭;终止条件 = 源枯竭 且 in-flight 清空,**不依赖 len**
  - `_ctx/_status/_results` 改 `dict[bi]` 懒建、**完成即释放**(未知长度 / 大规模源不堆内存)

  这让「有状态流式 reader」(actor 持迭代器、每次 run 吐一 batch、迭代器枯竭即停)天然可跑。
  
  ## Backward compatibility

  - `columns` 传 `list` 时走 `iter(list)`,老行为完全不变(同步同长、结果按序返回)。
  - 原「喂路径字符串 `List[List[str]]`」的调用方(如 Flash-MinerU)零改动。

  ## Testing

  - 核心 DAG 测 **19 passed,零回退**(3 个 `overlapped_pipeline` 失败为本 PR 前既有,已 stash 对照确认与本改动无关)。
  - 新验:喂生成器(未知长度)跑通;DataFrame batch 端到端表语义一路穿;跨-batch 流水线 overlap
    (inflight=6 → 2.11s vs 串行 3.62s)+ fan-out 分支并行(菱形单 batch 0.40s vs 串行 0.80s)保持。
  - **端到端回归(Flash-MinerU,368 PDF,4×GPU,inflight=4)**:改前 vs 改后 **844.08s vs 842.78s(0.15%,噪声内),吞吐 0.44 pdf/s 无差异** —— 对现有路径零性能影响。

  ## Files

  - `rayorch/container_ops.py`(新)
  - `rayorch/dag_new_pipeline.py` / `dispatch_mode.py` / `ray_module.py`(守卫 + 调度器)
