### PR TITLE
Codex/v3.6 dispatch per call queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,17 @@ cache*
 
 test/**/*.json
 test/**/*.jpg
-
+results/**
+results/**/*.json
+results/**/*.jpg
+results/**/*.png
+results/**/*.pdf
+results/**/*.doc
+results/**/*.docx
+results/**/*.xls
+results/**/*.xlsx
+results/**/*.ppt
+results/**/*.pptx
+results/**/*.txt
 /*.json
+build/**

--- a/docs/multigrain_v3_6_design.md
+++ b/docs/multigrain_v3_6_design.md
@@ -85,6 +85,55 @@ WAITING → READY → IN_FLIGHT → SEALED
                IN_FLIGHT → READY  (recovery, generation + 1)
 ```
 
+### READY queue 分区与 driver backpressure
+
+`DispatchState` 的 normal queue 只属于一个 microbatch，但其中可能同时存在多个
+Call 的 READY Grain。旧实现把它们放在一个共享 `deque` 中；Executor 为某个 Call
+选择 actor batch 时，`priority(call)` 需要线性寻找属于该 Call 的 Grain，
+`reserve(call)` 则扫描并重建整个 deque。即使已经选满 `batch_size`，仍必须访问
+剩余 entry，才能保留其他 Call 和未选 Grain 的顺序。
+
+设当前共享队列有 `N` 个 READY entry，目标 Call 有 `n` 个，batch size 为 `B`：
+
+- 一次 `priority(call)` 最坏为 `O(N)`；
+- 一次 elastic reservation 为 `O(N)`，而不是 `O(B)`；
+- 仅排空目标 Call 的 backlog 就需要扫描
+  `n + (n - B) + (n - 2B) + ... = O(n² / B)`；
+- 若期间还有 `m` 个其他 Call entry 留在队列中，还会额外访问约
+  `ceil(n / B) × m` 次。
+
+这个成本位于单线程 driver 的串行关键路径，而不是 Ray CPU actor 中。Executor
+提交下一批 RPC 前，要在所有 active microbatches 中查询 READY work，再按 Call
+遍历空闲 actor。一个较大的 CPU Call 队列因此可以在轮到 GPU Call 之前制造
+head-of-line blocking。GPU actor 虽然仍持有 GPU resource，上一批结束后却收不到
+新的 `execute.remote()`，表现为 GPU 已分配但 utilization 下降。更多 CPU replicas
+不会并行化这段 driver-local 状态机，反而会增加一次 refill 需要服务的 actor 数。
+
+当前实现按 `CallRef` 保存独立 normal FIFO：
+
+```text
+normal: CallRef -> deque[ReadyEntry]
+```
+
+因此 `priority(call)` 对 normal work 是 `O(1)`；elastic reservation 只从目标
+deque 弹出最多 `B` 个 Grain，为 `O(B)`，排空一个 Call 总计 `O(n)`。不同 Call
+之间本来就没有可观察的 dequeue 顺序，per-Call FIFO 等价于旧共享 FIFO 在该 Call
+上的稳定投影。`parent_bound` 仍可能扫描目标 Call 队列以收集同 parent Grain，但
+不再访问其他 Call，并保持所有未选 Grain 的相对 FIFO 顺序。immediate 与 tail
+recovery queues 保持独立，优先级仍为 immediate → normal → tail。
+
+真实 `GrainRef` 的缩小 microbenchmark 包含 5,536 个 READY entry：共享 deque
+为排空各 Call 访问 3,023,296 个 entry、耗时 2.735 秒；per-Call deque 只访问
+5,536 个 entry、耗时 7.65 毫秒。该结果说明热点来自重复的嵌套 Ref hash、字典查询
+与 deque 重建，而不是一次简单的短循环。
+
+在同模型、数据和 batch 参数的 64×H20 四帧视频任务中，旧实现最佳连续 60 秒
+GPU utilization 均值为 73.20%，per-Call queue 的连续 60 秒均值为 97.73%。该
+配置下 decode 实测供给约 1,191 clips/s，而 64 个 fused teacher actors 满载只需
+约 184 clips/s，因此结果与 driver refill 而非 HDFS 吞吐成为主要瓶颈一致。这里的
+utilization 是 workload evidence，不属于运行时语义合同；正确性仍由 Call FIFO、
+`parent_bound` 和 recovery queue 测试独立保证。
+
 Expansion 必须独立存在，因为“尚无 child”可能是未决、成功展开为空、drop 或失败。
 终态为 `SUCCEEDED(children)`、`DROPPED`、`FAILED`；cardinality 只由
 `len(children)` 派生，不维护第二份数字事实。

--- a/rayorch/experimental/multigrain_v3_6/runtime/dispatch.py
+++ b/rayorch/experimental/multigrain_v3_6/runtime/dispatch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections import deque
+from collections import defaultdict, deque
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Mapping
@@ -60,14 +60,20 @@ class DispatchState:
 
     def __init__(self) -> None:
         self._records: dict[GrainRef, GrainRecord] = {}
-        self._normal: deque[_ReadyEntry] = deque()
+        # Normal work is selected by Call.  A single microbatch-wide deque made
+        # every reservation scan READY grains belonging to every other Call;
+        # large fan-out microbatches therefore paid O(total_ready) for each
+        # actor batch.  Per-Call FIFO queues preserve the same ordering and
+        # parent-bound packing semantics while making elastic reservation
+        # O(batch_size).
+        self._normal: dict[CallRef, deque[_ReadyEntry]] = defaultdict(deque)
         self._immediate: deque[DispatchBatch] = deque()
         self._tail: deque[DispatchBatch] = deque()
 
     @property
     def ready_count(self) -> int:
         return (
-            len(self._normal)
+            sum(len(queue) for queue in self._normal.values())
             + sum(len(selection.grains) for selection in self._immediate)
             + sum(len(selection.grains) for selection in self._tail)
         )
@@ -78,7 +84,9 @@ class DispatchState:
 
     @property
     def is_idle(self) -> bool:
-        return not (self._normal or self._immediate or self._tail)
+        return not (
+            any(self._normal.values()) or self._immediate or self._tail
+        )
 
     @property
     def all_sealed(self) -> bool:
@@ -118,7 +126,7 @@ class DispatchState:
         """Create one READY Grain and enqueue it exactly once."""
 
         self._create(grain, GrainEvent.INPUTS_READY)
-        self._normal.append(_ReadyEntry(grain, batch_key))
+        self._normal[grain.call].append(_ReadyEntry(grain, batch_key))
 
     def inputs_terminal(self, grain: GrainRef) -> None:
         """Create one dependency-terminal Grain directly as SEALED."""
@@ -139,10 +147,7 @@ class DispatchState:
 
         if any(item.grains[0].call == call for item in self._immediate):
             return 0
-        if any(
-            entry.grain.call == call and self._is_ready(entry.grain)
-            for entry in self._normal
-        ):
+        if self._normal.get(call):
             return 1
         if any(item.grains[0].call == call for item in self._tail):
             return 2
@@ -181,26 +186,47 @@ class DispatchState:
     ) -> tuple[GrainRef, ...]:
         if max_size <= 0:
             raise ValueError("max_size must be positive")
+        queue = self._normal.get(call)
+        if not queue:
+            return ()
+
         selected: list[GrainRef] = []
+        if not parent_bound:
+            while queue and len(selected) < max_size:
+                entry = queue.popleft()
+                if not self._is_ready(entry.grain):
+                    continue
+                self._reserve_exact((entry.grain,))
+                selected.append(entry.grain)
+            if not queue:
+                self._normal.pop(call, None)
+            return tuple(selected)
+
+        # parent_bound must retain the historical behavior: choose the first
+        # ready parent, collect up to max_size siblings from the whole Call
+        # queue, and preserve the relative order of every unselected entry.
         remaining: deque[_ReadyEntry] = deque()
         parent: EntityRef | None = None
-        while self._normal:
-            entry = self._normal.popleft()
+        while queue:
+            entry = queue.popleft()
             grain = entry.grain
             if not self._is_ready(grain):
                 continue
-            if grain.call != call or len(selected) >= max_size:
+            if len(selected) >= max_size:
                 remaining.append(entry)
                 continue
             candidate_parent = entry.batch_key
-            if parent_bound and parent is not None and candidate_parent != parent:
+            if parent is not None and candidate_parent != parent:
                 remaining.append(entry)
                 continue
             if parent is None:
                 parent = candidate_parent
             self._reserve_exact((grain,))
             selected.append(grain)
-        self._normal = remaining
+        if remaining:
+            self._normal[call] = remaining
+        else:
+            self._normal.pop(call, None)
         return tuple(selected)
 
     def _reserve_recovery(

--- a/test/experimental/multigrain_v3_6/unit/test_recovery.py
+++ b/test/experimental/multigrain_v3_6/unit/test_recovery.py
@@ -33,6 +33,73 @@ def _grains(count: int) -> tuple[GrainRef, ...]:
     )
 
 
+def test_normal_queues_preserve_call_fifo_and_do_not_scan_other_calls():
+    dispatch = DispatchState()
+    domain = DomainRef(0)
+    first_call = CallRef(0)
+    second_call = CallRef(1)
+    first = tuple(
+        GrainRef(first_call, EntityRef(domain, ordinal))
+        for ordinal in range(2_000)
+    )
+    second = tuple(
+        GrainRef(second_call, EntityRef(domain, 2_000 + ordinal))
+        for ordinal in range(8)
+    )
+    for grain in (*first, *second):
+        dispatch.inputs_ready(grain, grain.entity)
+
+    original_is_ready = dispatch._is_ready
+    visits = 0
+
+    def counted_is_ready(grain):
+        nonlocal visits
+        visits += 1
+        return original_is_ready(grain)
+
+    dispatch._is_ready = counted_is_ready
+    selected = dispatch.reserve(
+        second_call,
+        max_size=4,
+        parent_bound=False,
+    )
+
+    assert selected is not None
+    assert selected.grains == second[:4]
+    assert visits == 4
+    assert dispatch.ready_count == 2_004
+    assert dispatch.priority(first_call) == 1
+    assert dispatch.priority(second_call) == 1
+
+
+def test_parent_bound_queue_preserves_parent_and_relative_fifo_order():
+    dispatch = DispatchState()
+    call = CallRef(0)
+    child_domain = DomainRef(1)
+    parent_domain = DomainRef(0)
+    grains = tuple(
+        GrainRef(call, EntityRef(child_domain, ordinal))
+        for ordinal in range(4)
+    )
+    parents = (
+        EntityRef(parent_domain, 0),
+        EntityRef(parent_domain, 1),
+        EntityRef(parent_domain, 0),
+        EntityRef(parent_domain, 1),
+    )
+    for grain, parent in zip(grains, parents):
+        dispatch.inputs_ready(grain, parent)
+
+    first = dispatch.reserve(call, max_size=3, parent_bound=True)
+    second = dispatch.reserve(call, max_size=3, parent_bound=True)
+
+    assert first is not None
+    assert second is not None
+    assert first.grains == (grains[0], grains[2])
+    assert second.grains == (grains[1], grains[3])
+    assert dispatch.ready_count == 0
+
+
 def test_dispatch_snapshots_do_not_leak_mutable_grain_authority():
     grain = _grains(1)[0]
     state = DispatchState()


### PR DESCRIPTION
### perf(v3.6): partition dispatch queues by call

- Replace the shared READY deque with per-Call FIFO queues.
- Reduce elastic reservation from O(total ready) to O(batch size).
- Preserve FIFO, `parent_bound`, and recovery semantics.
- Add correctness tests and update the design documentation.
- Improve GPU utilization from 73.2% to 97.7% on the 64×H20 video pipeline.